### PR TITLE
Fix hash rocket alignment, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,29 @@
 
 #### Table of Contents
 
-1. [Description - What is the dsc module and what does it do](#description)
-2. [Prerequisites](#windows-system-prerequisites)
-3. [Setup](#setup)
-4. [Usage](#usage)
-  * [Specifying a DSC Resource version](#specifying-a-dsc-resource-version)
-  * [Using PSCredential or MSFT_Credential](#using-pscredential-or-msft_credential)
-  * [Using EmbeddedInstance or CimInstance](#using-ciminstance)
-  * [Handling Reboots with DSC](#handling-reboots-with-dsc)
-5. [Reference](#reference)
-  * [Types and Providers](#types-and-providers)
-6. [Limitations](#limitations)
-  * [Known Issues](#known-issues)
-  * [Running Puppet and DSC without Administrative Privileges](#running-puppet-and-dsc-without-administrative-privileges)
+1. [Module Description - What the module does and why it is useful](#module-description)
+2. [Setup - The basics of getting started with dsc_lite](#setup)
+3. [Usage - Configuring options and additional functionality](#usage)
+    * [Specifying a DSC Resource version](#specifying-a-dsc-resource-version)
+    * [Using PSCredential or MSFT_Credential](#using-pscredential-or-msft_credential)
+    * [Using EmbeddedInstance or CimInstance](#using-ciminstance)
+    * [Handling Reboots with DSC](#handling-reboots-with-dsc)
+5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+    * [Types and Providers](#types-and-providers)
+6. [Limitations - OS compatibility, etc.](#limitations)
+    * [Known Issues](#known-issues)
+    * [Running Puppet and DSC without Administrative Privileges](#running-puppet-and-dsc-without-administrative-privileges)
 7. [Development - Guide for contributing to the module](#development)
 8. [Learn More About DSC](#learn-more-about-dsc)
 9. [License](#license)
 
-## Description
+## Module description
 
 The Puppet dsc_lite module allows you to manage target nodes using Windows PowerShell DSC (Desired State Configuration) Resources.
 
-## Windows System Prerequisites
+### Windows system prerequisites
 
- - At least PowerShell 5.0, which is included in [Windows Management Framework 5.0][wmf-5.0].
+At least PowerShell 5.0, which is included in [Windows Management Framework 5.0][wmf-5.0].
 
 ## Setup
 
@@ -42,9 +41,9 @@ See [known issues](#known-issues) for troubleshooting setup.
 
 ## Usage
 
-The generic `dsc` type is a streamlined and minimal representation of a DSC Resource declaration in Puppet syntax. You can use a DSC Resource by supplying the same properties you would set in a DSC Configuration script inside the `properties` parameter. For most use cases the `properties` parameter accepts the same structure as the PowerShell syntax, with the substitution of Puppet syntax for arrays, hashes and other data structures.
+The generic `dsc` type is a streamlined and minimal representation of a DSC Resource declaration in Puppet syntax. You can use a DSC Resource by supplying the same properties you would set in a DSC Configuration script, inside the `properties` parameter. For most use cases, the `properties` parameter accepts the same structure as the PowerShell syntax, with the substitution of Puppet syntax for arrays, hashes, and other data structures.
 
-So a DSC resource specified in PowerShell...
+A DSC resource specified in PowerShell:
 
 ~~~powershell
 WindowsFeature IIS {
@@ -53,13 +52,13 @@ WindowsFeature IIS {
 }
 ~~~
 
-...would look like this in Puppet:
+Would look like this in Puppet:
 
 ~~~puppet
 dsc {'iis':
-  resource_name        => 'WindowsFeature',
-  module      => 'PSDesiredStateConfiguration',
-  properties  => {
+  resource_name => 'WindowsFeature',
+  module        => 'PSDesiredStateConfiguration',
+  properties    => {
     ensure => 'present',
     name   => 'Web-Server',
   }
@@ -68,21 +67,21 @@ dsc {'iis':
 
 For the simplest cases, the above example is enough. However there are more advanced use cases in DSC that require more custom syntax in the `dsc` Puppet type. Since the `dsc` Puppet type has no prior knowledge of the type for each property in a DSC Resource, it can't format the hash correctly without some hints.
 
-The `properties` parameter will recognize any key with a hash value that contains two keys: `dsc_type` and `dsc_properties`, as a indication of how to format the data supplied. The `dsc_type` contains the CimInstance name to use, and the `dsc_properties` contains a hash or an array of hashes representing the data for the CimInstances.
+The `properties` parameter recognizes any key with a hash value that contains two keys: `dsc_type` and `dsc_properties`, as a indication of how to format the data supplied. The `dsc_type` contains the CimInstance name to use, and the `dsc_properties` contains a hash or an array of hashes, representing the data for the CimInstances.
 
 A contrived, but simple example follows:
 
 ~~~puppet
 dsc {'foo':
-  resource_name        => 'xFoo',
-  module      => 'xFooBar',
-  properties  => {
+  resource_name => 'xFoo',
+  module        => 'xFooBar',
+  properties    => {
     ensure  => 'present',
     fooinfo => {
       'dsc_type'       => 'FooBarBaz',
       'dsc_properties' => {
-        "wakka"      => "woot",
-        "number"     => 8090
+        "wakka"  => "woot",
+        "number" => 8090
       }
     }
   }
@@ -91,16 +90,16 @@ dsc {'foo':
 
 ### Specifying a DSC Resource version
 
-When there is more than one version installed for a given DSC Resource module, you must specify the version in your declaration. You can specify the version with similar syntax to a DSC Configuration script by using a hash containing the name and version of the DSC Resource module to use.
+When there is more than one version installed for a given DSC Resource module, you must specify the version in your declaration. You can specify the version with similar syntax to a DSC configuration script, by using a hash containing the name and version of the DSC Resource module.
 
 ~~~puppet
 dsc {'iis_server':
-  resource_name   => 'WindowsFeature',
-  module => {
+  resource_name => 'WindowsFeature',
+  module        => {
     name    => 'PSDesiredStateConfiguration',
     version => '1.1'
   },
-  properties  => {
+  properties => {
     ensure => 'present',
     name   => 'Web-Server',
   }
@@ -113,9 +112,9 @@ There are several methods to distribute DSC Resources to the target nodes for th
 
 #### PowerShell Gallery
 
-You can choose to install DSC Resources yourself using a mechanism that calls the builtin PowerShell package management system called `PackageManagement`, which uses the `PowerShellGet` module and pulls from the [PowerShell Gallery](https://www.powershellgallery.com). You would be responsible for orchestrating this before Puppet is run on the host, or you could do so using `exec` in your Puppet manifest. This gives you control of the process, but requires you to manage the complexity yourself.
+You can choose to install DSC Resources using a mechanism that calls the builtin PowerShell package management system called `PackageManagement`. It uses the `PowerShellGet` module and pulls from the [PowerShell Gallery](https://www.powershellgallery.com). You are responsible for orchestrating this before Puppet is run on the host, or you can do so using `exec` in your Puppet manifest. This gives you control of the process, but requires you to manage the complexity yourself.
 
-The following example shows how to install the `xPSDesiredStateConfiguration` DSC Resource, and could be extended to support different DSC Resource names. This example assumes a package repository was configured already.
+The following example shows how to install the `xPSDesiredStateConfiguration` DSC Resource, and can be extended to support different DSC Resource names. This example assumes a package repository has been configured.
 
 ~~~puppet
 exec { 'xPSDesiredStateConfiguration-Install':
@@ -126,7 +125,7 @@ exec { 'xPSDesiredStateConfiguration-Install':
 
 #### Puppet hbuckle/powershellmodule module
 
-A community created module [hbuckle/powershellmodule](https://forge.puppet.com/hbuckle/powershellmodule) handles using `PackageMangement` and `PowerShellGet` to download and install DSC Resources on target nodes. It is another Puppet `package` provider, so it looks and feels like how you install packages with Puppet for any other use case.
+The community created module [hbuckle/powershellmodule](https://forge.puppet.com/hbuckle/powershellmodule) handles using `PackageMangement` and `PowerShellGet` to download and install DSC Resources on target nodes. It is another Puppet `package` provider, so it similar to how you install packages with Puppet for any other use case.
 
 Installing a DSC Resource can be as simple as the following declaration:
 
@@ -138,11 +137,11 @@ package { 'xPSDesiredStateConfiguration':
 }
 ~~~
 
-The module supports configuring repository sources and other `PackageManagement` options like configuring trusted package repositories and private or on-premise package sources. For more information please refer to the [forge page](https://forge.puppet.com/hbuckle/powershellmodule).
+The module supports configuring repository sources and other `PackageManagement` options, for example configuring trusted package repositories and private or on-premise package sources. For more information, please see the [forge page](https://forge.puppet.com/hbuckle/powershellmodule).
 
 #### Chocolatey
 
-Puppet already works well with [chocolatey](https://chocolatey.org/), so you can create chocolatey packages that wrap the DSC Resources you need. 
+Puppet already works well with [chocolatey](https://chocolatey.org/). You can create chocolatey packages that wrap the DSC Resources you need. 
 
 ~~~puppet
 package { 'xPSDesiredStateConfiguration':
@@ -151,17 +150,17 @@ package { 'xPSDesiredStateConfiguration':
 }
 ~~~
 
-This works well for users that already have a chocolatey source feed setup internally, as all that's needed is to push the DSC Resource chocolatey packages to the internal feed. If you use the community feed, you will have to check that the DSC Resource you use is present there.
+This works well for users that already have a chocolatey source feed setup internally, as all you need to do is to push the DSC Resource chocolatey packages to the internal feed. If you use the community feed, you will have to check that the DSC Resource you use is present there.
 
 ### Using PSCredential or MSFT_Credential
 
-Specifying credentials in DSC Resources requires using a PSCredential object. The `dsc` type will automatically create a PSCredential if the `dsc_type` has `MSFT_Credential` as a value.
+Specifying credentials in DSC Resources requires using a PSCredential object. The `dsc` type automatically creates a PSCredential if the `dsc_type` has `MSFT_Credential` as a value.
 
 ~~~puppet
 dsc {'foouser':
-  resource_name       => 'User',
-  module     => 'PSDesiredStateConfiguration',
-  properties => {
+  resource_name => 'User',
+  module        => 'PSDesiredStateConfiguration',
+  properties    => {
     'username'    => 'jane-doe',
     'description' => 'Jane Doe user',
     'ensure'      => 'present',
@@ -169,7 +168,7 @@ dsc {'foouser':
       'dsc_type'       => 'MSFT_Credential',
       'dsc_properties' => {
         'user'     => 'jane-doe',
-        'password' => 'StartFooo123&^!'
+        'password' => Sensitive('StartFooo123&^!')
       }
     },
     'passwordneverexpires' => false,
@@ -178,15 +177,15 @@ dsc {'foouser':
 }
 ~~~
 
-Some DSC Resources require a password or passphrase for a setting, but do not need a user name. All credentials in DSC must be a PSCredential, so these passwords still have to be specified in a PSCredential format, even if there is no `user` to specify. How you specify the PSCredential will depend on how the DSC Resource implemented the password requirement. Some DSC Resources will accept an empty or null string for `user`, others do not. If it does not accept an empty or null string, then specify a dummy value. Do not use `undef` as it will error out.
+Some DSC Resources require a password or passphrase for a setting, but do not need a user name. All credentials in DSC must be a PSCredential, so these passwords still have to be specified in a PSCredential format, even if there is no `user` to specify. How you specify the PSCredential depends on how the DSC Resource implemented the password requirement. Some DSC Resources accept an empty or null string for `user`, others do not. If it does not accept an empty or null string, then specify a dummy value. Do not use `undef` as it will error out.
 
 You can also use the Puppet [Sensitive type](https://puppet.com/docs/puppet/latest/lang_data_sensitive.html) to ensure logs and reports redact the password.
 
 ~~~puppet
 dsc {'foouser':
-  resource_name       => 'User',
-  module     => 'PSDesiredStateConfiguration',
-  properties => {
+  resource_name => 'User',
+  module        => 'PSDesiredStateConfiguration',
+  properties    => {
     'username'    => 'jane-doe',
     'description' => 'Jane Doe user',
     'ensure'      => 'present',
@@ -205,15 +204,15 @@ dsc {'foouser':
 
 ### Using CimInstance
 
-A DSC Resource may need a more complex type than a simple key value pair, so an EmbeddedInstance is used. An EmbeddedInstance is serialized as CimInstance over the wire. In order to represent a CimInstance in the `dsc` type, we will use the `dsc_type` key to specify which CimInstance to use. If the CimInstance is an array, we append a `[]` to the end of the name.
+A DSC Resource may need a more complex type than a simple key value pair, for example, an EmbeddedInstance. An EmbeddedInstance is serialized as CimInstance over the wire. In order to represent a CimInstance in the `dsc` type, use the `dsc_type` key to specify which CimInstance to use. If the CimInstance is an array, append a `[]` to the end of the name.
 
-For example, we'll create a new IIS website using the xWebSite DSC Resource, bound to port 80. We use `dsc_type` to specify a `MSFT_xWebBindingInformation` CimInstance, and append `[]` to indicate that it is an array. Note that we do this even if we are only putting a single value in `dsc_properties`.
+For example, create a new IIS website using the xWebSite DSC Resource, bound to port 80. Use `dsc_type` to specify a `MSFT_xWebBindingInformation` CimInstance, and append `[]` to indicate that it is an array. Note that you do this even if you are only putting a single value in `dsc_properties`.
 
 ~~~puppet
 dsc {'NewWebsite':
-  resource_name        => 'xWebsite',
-  module      => 'xWebAdministration',
-  properties  => {
+  resource_name => 'xWebsite',
+  module        => 'xWebAdministration',
+  properties    => {
     ensure       => 'Present',
     state        => 'Started',
     name         => 'TestSite',
@@ -229,13 +228,13 @@ dsc {'NewWebsite':
 }
 ~~~
 
-To show using more than one value in `dsc_properties`, let's create the same site but now bound to both port 80 and 443.
+To show using more than one value in `dsc_properties`, create the same site but bound to both port 80 and 443.
 
 ~~~puppet
 dsc {'NewWebsite':
-  resource_name        => 'xWebsite',
-  module      => 'xWebAdministration',
-  properties  => {
+  resource_name => 'xWebsite',
+  module        => 'xWebAdministration',
+  properties    => {
     ensure       => 'Present',
     state        => 'Started',
     name         => 'TestSite',
@@ -260,7 +259,7 @@ dsc {'NewWebsite':
 }
 ~~~
 
-### Handling Reboots with DSC
+### Handling reboots with DSC
 
 Add the following `reboot` resource to your manifest. It must have the name `dsc_reboot` for the `dsc` module to find and use it.
 
@@ -275,13 +274,11 @@ reboot { 'dsc_reboot' :
 
 ### Types and Providers
 
-* [dsc](#dsc)
-
-### dsc
+#### dsc
 
 The `dsc` type allows specifying any DSC Resource declaration as a minimal Puppet declaration.
 
-#### Properties/Parameters
+### Properties/Parameters
 
 #### name
 
@@ -289,7 +286,7 @@ The name of the declaration. This has no affect on the DSC Resource declaration 
 
 #### ensure
 
-An optional property that specifies that the DSC resource should be invoked.
+An optional property that specifies the DSC resource should be invoked.
 This property has only one value of `present`.
 This property does not need be be set in manifests.
 
@@ -305,15 +302,13 @@ The name of the DSC Resource module to use. For example, the xPSDesiredStateConf
 
 The hash of properties to pass to the DSC Resource.
 
-To express EmbeddedInstances, the `properties` parameter will recognize any key with a hash value that contains two keys: `dsc_type` and `dsc_properties`, as a indication of how to format the data supplied. The `dsc_type` contains the CimInstance name to use, and the `dsc_properties` contains a hash or an array of hashes representing the data for the CimInstances. If the CimInstance is an array, we append a `[]` to the end of the name.
+To express EmbeddedInstances, the `properties` parameter recognizes any key with a hash value that contains two keys — `dsc_type` and `dsc_properties` — as a indication of how to format the data supplied. The `dsc_type` contains the CimInstance name to use, and the `dsc_properties` contains a hash or an array of hashes representing the data for the CimInstances. If the CimInstance is an array, we append a `[]` to the end of the name.
 
 ## Limitations
 
-- For a list of tradeoffs and improvements in the dsc_lite module compared to the dsc module, see [README_Tradeoffs.md](https://github.com/puppetlabs/puppetlabs-dsc_lite/blob/master/README_Tradeoffs.md)
-
-- DSC Composite Resources are not supported.
-
-- DSC requires PowerShell `Execution Policy` for the `LocalMachine` scope to be set to a less restrictive setting than `Restricted`. If you see the error below, see [MODULES-2500](https://tickets.puppet.com/browse/MODULES-2500) for more information.
+* For a list of tradeoffs and improvements in the dsc_lite module compared to the dsc module, see [README_Tradeoffs.md](https://github.com/puppetlabs/puppetlabs-dsc_lite/blob/master/README_Tradeoffs.md)
+* DSC Composite Resources are not supported.
+* DSC requires PowerShell `Execution Policy` for the `LocalMachine` scope to be set to a less restrictive setting than `Restricted`. If you see the error below, see [MODULES-2500](https://tickets.puppet.com/browse/MODULES-2500) for more information.
 
   ~~~
   Error: /Stage[main]/Main/Dsc_xgroup[testgroup]: Could not evaluate: Importing module MSFT_xGroupResource failed with
@@ -323,25 +318,22 @@ To express EmbeddedInstances, the `properties` parameter will recognize any key 
   information, see about_Execution_Policies at http://go.microsoft.com/fwlink/?LinkID=135170.
   ~~~
 
-- You cannot use forward slashes for the MSI `Path` property for the `Package` DSC Resource. The underlying implementation does not accept forward slashes instead of backward slashes in paths, and it throws a misleading error that it could not find a Package with the Name and ProductId provided. [MODULES-2486](https://tickets.puppet.com/browse/MODULES-2486) has more examples and information on this subject.
-
-- Use of this module with the 3.8.x x86 version of Puppet is highly discouraged, though supported.  Normally, this module employs a technique to dramatically improve performance by reusing a PowerShell process to execute DSC related commands.  However, due to the Ruby 1.9.3 runtime used with the 3.8.x x86 version of Puppet, this technique must be disabled, resulting in at least a 2x slowdown.
+* You cannot use forward slashes for the MSI `Path` property for the `Package` DSC Resource. The underlying implementation does not accept forward slashes instead of backward slashes in paths, and it throws a misleading error that it could not find a Package with the Name and ProductId provided. See [MODULES-2486](https://tickets.puppet.com/browse/MODULES-2486) for more examples and information on this subject.
+* Using this module with the 3.8.x x86 version of Puppet is highly discouraged, though it is supported.  Normally, this module employs a technique to dramatically improve performance by reusing a PowerShell process to execute DSC related commands.  However, due to the Ruby 1.9.3 runtime used with the 3.8.x x86 version of Puppet, this technique must be disabled, resulting in at least a 2x slowdown.
 
 ### Known Issues
 
-- `--noop` mode, `puppet resource` and property change notifications are currently not implemented - see [MODULES-2270](https://tickets.puppet.com/browse/MODULES-2270) for details.
+`--noop` mode, `puppet resource` and property change notifications are currently not implemented. See [MODULES-2270](https://tickets.puppet.com/browse/MODULES-2270) for details.
 
-### Running Puppet and DSC without Administrative Privileges
+### Running Puppet and DSC without administrative privileges
 
-While there are avenues for using Puppet with a non-administrative account, DSC is limited to only accounts with administrative privileges. The underlying CIM implementation DSC uses for DSC Resource invocation requires administrative credentials to function.
+While there are options for using Puppet with a non-administrative account, DSC is limited to accounts with administrative privileges. The underlying CIM implementation DSC uses for DSC Resource invocation, and the Invoke-DscResource cmdlet, require administrative credentials.
 
-- Using the Invoke-DscResource cmdlet requires administrative credentials
-
-The Puppet agent on a Windows node can run DSC with a normal default install. If the Puppet agent was configured to use an alternate user account, that account must have administrative privileges on the system in order to run DSC.
+The Puppet agent on a Windows node can run DSC with a normal default install. If the Puppet agent is configured to use an alternate user account, it must have administrative privileges on the system to run DSC.
 
 ## Troubleshooting
 
-When Puppet runs, the dsc_lite module takes the code supplied in your puppet manifest and converts that into PowerShell code that is sent to the DSC engine directly using `Invoke-DscResource`. You can see both the commands sent and the result of this by running puppet interactively, e.g. `puppet apply --debug`. It will output the PowerShell code that is sent to DSC to execute and the return data from DSC. For example:
+When Puppet runs, the dsc_lite module takes the code supplied in your Puppet manifest and converts it into PowerShell code that is sent directly to the DSC engine using `Invoke-DscResource`. You can see both the commands sent and the result of this by running Puppet interactively, for example, `puppet apply --debug`. It outputs the PowerShell code that is sent to DSC to execute and return data from DSC. For example:
 
 ```puppet
 Notice: Compiled catalog for win2012r2 in environment production in 0.82 seconds
@@ -381,7 +373,7 @@ ModuleName = 'ExampleDscResourceModule'
 ############### SNIP ################\
 Debug: Waited 100 total milliseconds.
 Debug: Create Dsc Resource returned: {"rebootrequired":false,"indesiredstate":true,"errormessage":""}
-Notice: /Stage[main]/Main/Dsc_exampledscresource[foober]/ensure: created
+Notice: /Stage[main]/Main/Dsc_exampledscresource[foober]/ensure: invoked
 Debug: /Stage[main]/Main/Dsc_exampledscresource[foober]: The container Class[Main] will propagate my refresh event
 Debug: Class[Main]: The container Stage[main] will propagate my refresh event
 Debug: Finishing transaction 56434520
@@ -390,13 +382,13 @@ Debug: Stored state in 0.10 seconds
 ############### SNIP ################
 ```
 
-This shows us that there wasn't any problem parsing your manifest and turning it into a command to send to DSC. It also shows that there are two commands/operations for every DSC Resource executed, a SET and a test. DSC operates in two stages, it first tests if a system is in the desired state, then it sets the state of the system to the desired state. You can see the result of each operation in the debug log.
+This shows us that there wasn't a problem parsing the manifest and turning it into a command to send to DSC. It also shows that there are two commands/operations for every DSC Resource executed, a SET and a test. DSC operates in two stages, it first tests if a system is in the desired state, and then it sets the state of the system to the desired state. You can see the result of each operation in the debug log.
 
-By using the debug logging of a puppet run, you can troubleshoot the application of DSC Resources during the development of your puppet manifests.
+By using the debug logging of a Puppet run, you can troubleshoot the application of DSC Resources during the development of your Puppet manifests.
 
 ## Development
 
-Puppet Inc modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
+Puppet modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
 
 We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 


### PR DESCRIPTION
Fix Hash rocket alignment, bullet indentation, and change verbiage to invoked from created in one of the examples.